### PR TITLE
Verify Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "webpack --watch",
     "start": "nodemon ./src/server/index.ts",
     "update": "rimraf node_modules && rm package-lock.json && npm install && exit 1",
-    "seed": "ts-node ./src/server/db/seeds/index.ts"
+    "seed": "ts-node ./src/server/db/seeds/index.ts",
+    "seedEvents": "ts-node ./src/server/db/seeds/seedEvents.ts"
   },
   "repository": {
     "type": "git",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -145,9 +145,15 @@ app.get('/logout', async (req: any, res: any) => {
       console.error('Error logging out user', error);
       res.sendStatus(500);
     } else {
-      await req.session.destroy();
-      await req.sessionStore.clear();
-      res.redirect('/');
+      req.session.destroy((error: Error) => {
+        if (error) {
+          console.error('Error destroying session:', error);
+          res.sendStatus(500);
+        } else {
+          res.clearCookie('google-auth-session');
+          res.redirect('/');
+        }
+      });
     }
   });
 });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,7 +6,7 @@ import session from 'express-session';
 import passport from 'passport';
 import dotenv from 'dotenv';
 
-import verifySession from './verify';
+import { verifySessionApi, verifySessionView } from './verify';
 import apiRouter from './api';
 import User from './db/models/users';
 
@@ -59,7 +59,7 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 // For all router endpoints, start with /api
-app.use('/api', apiRouter);
+app.use('/api', verifySessionApi, apiRouter);
 
 passport.use(
   new GoogleStrategy(
@@ -152,7 +152,7 @@ app.get('/logout', async (req: any, res: any) => {
   });
 });
 
-app.get('*', verifySession, (req: any, res: any) => {
+app.get('*', verifySessionView, (req: any, res: any) => {
   res.sendFile('index.html', {
     root: path.resolve(__dirname, '..', '..', 'dist'),
   });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -6,6 +6,7 @@ import session from 'express-session';
 import passport from 'passport';
 import dotenv from 'dotenv';
 
+import verifySession from './verify';
 import apiRouter from './api';
 import User from './db/models/users';
 
@@ -151,7 +152,7 @@ app.get('/logout', async (req: any, res: any) => {
   });
 });
 
-app.all('*', (req: any, res: any) => {
+app.get('*', verifySession, (req: any, res: any) => {
   res.sendFile('index.html', {
     root: path.resolve(__dirname, '..', '..', 'dist'),
   });

--- a/src/server/db/models/users_notifications.ts
+++ b/src/server/db/models/users_notifications.ts
@@ -3,7 +3,9 @@ import database from '../index';
 import User from './users';
 import Notification from './notifications';
 
-const User_Notification = database.define('User_Notification', {});
+const User_Notification = database.define('User_Notification', {
+  seen: { type: Sequelize.BOOLEAN, defaultValue: false },
+});
 
 User.belongsToMany(Notification, { through: User_Notification });
 Notification.belongsToMany(User, { through: User_Notification });

--- a/src/server/db/seeds/index.ts
+++ b/src/server/db/seeds/index.ts
@@ -1,5 +1,4 @@
 import seedCategories from './seedCategories';
-import eventsSeed from './seedEvents';
 import seedInterests from './seedInterests';
 import seedTasks from './seedTasks';
 import seedVenues from './seedVenues';
@@ -9,7 +8,6 @@ async function seedDb() {
   await seedCategories();
   await seedInterests();
   await seedTasks();
-  eventsSeed();
 }
 
 seedDb();

--- a/src/server/db/seeds/seedEvents.ts
+++ b/src/server/db/seeds/seedEvents.ts
@@ -183,10 +183,6 @@ const seedEvents = async () => {
   }
 };
 
-const eventsSeed = () => {
-  setTimeout(() => {
-    seedEvents();
-  }, 2000);
-};
-
-export default eventsSeed;
+setTimeout(() => {
+  seedEvents();
+}, 2000);

--- a/src/server/verify.ts
+++ b/src/server/verify.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+
+// Middleware to verify sessions when a user is using the site
+const verifySession = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    res.redirect('/');
+  } else {
+    next();
+  }
+};
+
+export default verifySession;

--- a/src/server/verify.ts
+++ b/src/server/verify.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 
 // Middleware to verify sessions when a user is using the site
-const verifySession = (req: Request, res: Response, next: NextFunction) => {
+const verifySessionView = (req: Request, res: Response, next: NextFunction) => {
   if (!req.user) {
     res.redirect('/');
   } else {
@@ -9,4 +9,12 @@ const verifySession = (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
-export default verifySession;
+const verifySessionApi = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    res.sendStatus(401);
+  } else {
+    next();
+  }
+};
+
+export { verifySessionView, verifySessionApi };


### PR DESCRIPTION
- Separated seedEvents from general seed since we don't want random events seeded in production
- Add `seen` field to User_Notification model to track if a user has seen a notification
- Verify a user session on:
  - Changing views: redirect to '/' if there is no req.user
  - Using /api endpoints: Send 401 status: Unauthorized to prevent any usage
- Fix: Cookies weren't clearing. Adjusted /logout endpoint to guarantee cookies are cleared