### PR TITLE
Notifications finish crud

### DIFF
--- a/src/client/components/notifications-view/Notification.tsx
+++ b/src/client/components/notifications-view/Notification.tsx
@@ -26,7 +26,7 @@ type NotificationProps = {
 function Notification({ notif, getNotifications }: NotificationProps) {
   const deleteNotification = () => {
     axios
-      .delete(`/api/notifications/${notif.id}`)
+      .delete(`/api/notifications/${notif.id}/delete`)
       .then(getNotifications)
       .catch((err: unknown) => {
         console.error('Failed to deleteNotification:', err);

--- a/src/client/components/notifications-view/Notification.tsx
+++ b/src/client/components/notifications-view/Notification.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
+import axios from 'axios';
 import dayjs from 'dayjs';
+
+import { MdDeleteForever } from "react-icons/md";
 
 import {
   Card,
@@ -17,15 +20,30 @@ type NotificationProps = {
       seen: boolean;
     };
   };
+  getNotifications: () => void;
 };
 
-function Notification({ notif }: NotificationProps) {
+function Notification({ notif, getNotifications }: NotificationProps) {
+  const deleteNotification = () => {
+    axios
+      .delete(`/api/notifications/${notif.id}`)
+      .then(getNotifications)
+      .catch((err: unknown) => {
+        console.error('Failed to deleteNotification:', err);
+      });
+  };
+
   return (
     <Card
       className={`ml-4 mr-4 mb-4 ${notif.User_Notification.seen ? '' : ' bg-cyan-100'}`}
     >
       <CardHeader>
-        <CardTitle>{notif.message}</CardTitle>
+        <CardTitle>
+          <div className="grid grid-cols-12 gap-2">
+            <div className="col-span-11">{notif.message}</div>
+            <MdDeleteForever size={20} onClick={deleteNotification} />
+          </div>
+        </CardTitle>
         <CardDescription>
           {dayjs(notif.send_time).format('h:mm a, MMM. D')}
         </CardDescription>

--- a/src/client/components/notifications-view/NotificationList.tsx
+++ b/src/client/components/notifications-view/NotificationList.tsx
@@ -11,14 +11,15 @@ type NotificationListProps = {
       seen: boolean;
     };
   }[];
+  getNotifications: () => void;
 };
 
-function NotificationList({ notifs }: NotificationListProps) {
+function NotificationList({ notifs, getNotifications }: NotificationListProps) {
   return (
     <>
       {notifs.map((notif: any) => (
         <div key={notif.id}>
-          <Notification notif={notif} />
+          <Notification notif={notif} getNotifications={getNotifications} />
         </div>
       ))}
     </>

--- a/src/client/contexts/UserContext.ts
+++ b/src/client/contexts/UserContext.ts
@@ -8,8 +8,8 @@ export interface UserType {
   full_name?: string;
   phone_number?: string;
   total_tasks_completed?: number;
-  weekly_task_count: number;
-  last_week_task_count: number;
+  weekly_task_count?: number;
+  last_week_task_count?: number;
   events_attended?: number;
   location?: string;
   avatar_id?: number;

--- a/src/client/views/Notifications.tsx
+++ b/src/client/views/Notifications.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useState, useCallback, useEffect } from 'react';
 import axios from 'axios';
 
+import { Button } from '../../components/ui/button';
+
 import { UserContext } from '../contexts/UserContext';
 
 import NotificationList from '../components/notifications-view/NotificationList';
@@ -30,6 +32,15 @@ function Notifications() {
       });
   }, [getUser, notifs]);
 
+  const deleteAllNotifications = () => {
+    axios
+      .delete('/api/notifications/all')
+      .then(getNotifications)
+      .catch((err: unknown) => {
+        console.error('Failed to deleteAllNotifications:', err);
+      });
+  };
+
   useEffect(() => {
     getNotifications();
   }, [getNotifications]);
@@ -39,7 +50,10 @@ function Notifications() {
   }, [notifs]);
 
   return (
-    <div className="container pt-20 pb-8">
+    <div className="container pt-20 pb-8 flex flex-col items-center">
+      <Button className="mb-5" onClick={deleteAllNotifications}>
+        Clear All Notifications
+      </Button>
       <NotificationList notifs={notifs} getNotifications={getNotifications} />
     </div>
   );

--- a/src/client/views/Notifications.tsx
+++ b/src/client/views/Notifications.tsx
@@ -6,7 +6,7 @@ import { UserContext } from '../contexts/UserContext';
 import NotificationList from '../components/notifications-view/NotificationList';
 
 function Notifications() {
-  const { user } = useContext(UserContext);
+  const { getUser } = useContext(UserContext);
 
   const [notifs, setNotifs] = useState<any>([]);
 
@@ -21,9 +21,22 @@ function Notifications() {
       });
   }, []);
 
+  const patchNotificationsSeenAll = useCallback(() => {
+    axios
+      .patch('/api/notifications/seen/all', { notifications: notifs })
+      .then(getUser)
+      .catch((err: unknown) => {
+        console.error('Failed to patchNotificationsSeenAll', err);
+      });
+  }, [getUser, notifs]);
+
   useEffect(() => {
     getNotifications();
   }, [getNotifications]);
+
+  useEffect(() => {
+    patchNotificationsSeenAll();
+  }, [notifs]);
 
   return (
     <div className="container pt-20 pb-8">

--- a/src/client/views/Notifications.tsx
+++ b/src/client/views/Notifications.tsx
@@ -40,7 +40,7 @@ function Notifications() {
 
   return (
     <div className="container pt-20 pb-8">
-      <NotificationList notifs={notifs} />
+      <NotificationList notifs={notifs} getNotifications={getNotifications} />
     </div>
   );
 }

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -188,13 +188,12 @@ event2Router.patch('/attending/:id', async (req: any, res: Response) => {
       });
     } else {
       // If a user bails on an event, destroy the notification.
-      const hourBeforeNotif: any = await User_Notification.findOne({
+      await User_Notification.destroy({
         where: {
           UserId: req.user.id,
           NotificationId: event.notificationId,
         },
       });
-      await hourBeforeNotif.destroy();
     }
 
     await userEvent.save();

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -85,7 +85,7 @@ notifsRouter.patch('/seen/all', (req: any, res: Response) => {
 /*
   DELETE /api/notifications/:id => Delete one notification for a user
 */
-notifsRouter.delete('/:id', (req: any, res: Response) => {
+notifsRouter.delete('/:id/delete', (req: any, res: Response) => {
   User_Notification.destroy({
     where: {
       UserId: req.user.id,
@@ -119,7 +119,15 @@ notifsRouter.delete('/all', async (req: any, res: Response) => {
         },
       ],
     });
-    console.log(user);
+    
+    const notificationIds = user?.dataValues.Notifications.reduce(
+      (acc: number[], curr: any) => {
+        acc.push(curr.dataValues.id);
+        return acc;
+      },
+      []
+    );
+    console.log(notificationIds);
     // User_Notification.destroy({ where: { UserId: req.user.id } });
     res.sendStatus(200);
   } catch (err: unknown) {

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -51,10 +51,28 @@ notifsRouter.get('/', (req: any, res: Response) => {
 
 /*
   PATCH /api/notifications/seen/all =>
+   - Must send all of the notifications rendered in the view
 */
 notifsRouter.patch('/seen/all', (req: any, res: Response) => {
+  const { notifications } = req.body;
+  // Grab all of the unread notification ids
+  const unreadNotifs = notifications.reduce((acc: number[], curr: any) => {
+    if (!curr.User_Notification.seen) {
+      acc.push(curr.id);
+    }
+    return acc;
+  }, []);
+
   // Query User_Notifications table for all user notifs update all seen to true
-  User_Notification.update({ seen: true }, { where: { UserId: req.user.id } })
+  User_Notification.update(
+    { seen: true },
+    {
+      where: {
+        UserId: req.user.id,
+        NotificationId: unreadNotifs,
+      },
+    }
+  )
     .then(() => {
       res.sendStatus(200);
     })
@@ -85,6 +103,7 @@ notifsRouter.delete('/:id', (req: any, res: Response) => {
 
 /*
   DELETE /api/notifications/all => Delete all notifications for a user
+    - Needs to only delete the notifications that have been sent
 */
 notifsRouter.delete('/all', (req: any, res: Response) => {
   User_Notification.destroy({ where: { UserId: req.user.id } })

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -105,15 +105,27 @@ notifsRouter.delete('/:id', (req: any, res: Response) => {
   DELETE /api/notifications/all => Delete all notifications for a user
     - Needs to only delete the notifications that have been sent
 */
-notifsRouter.delete('/all', (req: any, res: Response) => {
-  User_Notification.destroy({ where: { UserId: req.user.id } })
-    .then(() => {
-      res.sendStatus(200);
-    })
-    .catch((err: unknown) => {
-      console.error('Failed to DELETE /api/notifications/all', err);
-      res.sendStatus(500);
+notifsRouter.delete('/all', async (req: any, res: Response) => {
+  try {
+    const user = await User.findOne({
+      where: {
+        id: req.user.id,
+      },
+      include: [
+        {
+          model: Notification,
+          where: { send_time: { [Op.lt]: new Date(Date.now()) } },
+          required: false,
+        },
+      ],
     });
+    console.log(user);
+    // User_Notification.destroy({ where: { UserId: req.user.id } });
+    res.sendStatus(200);
+  } catch (err: unknown) {
+    console.error('Failed to DELETE /api/notifications/all', err);
+    res.sendStatus(500);
+  }
 });
 
 export default notifsRouter;

--- a/src/server/routes/notifications.ts
+++ b/src/server/routes/notifications.ts
@@ -127,8 +127,9 @@ notifsRouter.delete('/all', async (req: any, res: Response) => {
       },
       []
     );
-    console.log(notificationIds);
-    // User_Notification.destroy({ where: { UserId: req.user.id } });
+    User_Notification.destroy({
+      where: { UserId: req.user.id, NotificationId: notificationIds },
+    });
     res.sendStatus(200);
   } catch (err: unknown) {
     console.error('Failed to DELETE /api/notifications/all', err);


### PR DESCRIPTION
- User's notifications are marked read when they visit the Notifications view
- User can remove an individual notification
- User can remove all notifications
- Small edit in Usercontext: using optional fields until everything is set in stone
- Found and fixed bug in deleting notification when bailing from an event
  - If the notification was already deleted, there would be an error on bailing
  - Switched from finding and then destroy to just using destroy method.