### PR TITLE
test / Test Events & Setup/Teardown

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
+  globalSetup: './tests/setup.ts',
+  globalTeardown: './tests/teardown.ts',
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Thesis Project",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --detectOpenHandles",
     "build": "webpack --watch",
     "start": "nodemon ./src/server/index.ts",
     "update": "rimraf node_modules && rm package-lock.json && npm install && exit 1",

--- a/src/server/db/models/events.ts
+++ b/src/server/db/models/events.ts
@@ -24,10 +24,8 @@ Event.belongsTo(User, { foreignKey: 'created_by', onDelete: 'CASCADE' });
 Event.belongsTo(Venue, { foreignKey: 'venue_id' });
 Event.belongsTo(Category, { foreignKey: 'category_id' });
 Category.hasMany(Event, { foreignKey: 'category_id' });
-Event.belongsToMany(Interest, { through: Event_Interest });
-Interest.belongsToMany(Event, { through: Event_Interest });
 Event.hasOne(Chatroom, { foreignKey: 'event_id' });
-Chatroom.belongsTo(Event, { foreignKey: 'event_id' });
+Chatroom.belongsTo(Event, { foreignKey: 'event_id', onDelete: 'CASCADE' });
 Event.belongsTo(Notification, { foreignKey: 'hour_before_notif' });
 
 export default Event;

--- a/src/server/db/models/events_interests.ts
+++ b/src/server/db/models/events_interests.ts
@@ -1,5 +1,13 @@
 import database from '../index';
+import Event from './events';
+import Interest from './interests';
 
 const Event_Interest = database.define('Event_Interest', {});
+
+Event.belongsToMany(Interest, { through: Event_Interest });
+Interest.belongsToMany(Event, { through: Event_Interest });
+
+Event_Interest.belongsTo(Event, { onDelete: 'CASCADE' });
+Event_Interest.belongsTo(Interest);
 
 export default Event_Interest;

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,0 +1,137 @@
+import database from '../src/server/db';
+import http, { Server } from 'http';
+import axios from 'axios';
+import express, { Application } from 'express';
+
+import apiRouter from '../src/server/api';
+import User from '../src/server/db/models/users';
+import Event from '../src/server/db/models/events';
+import Interest from '../src/server/db/models/interests';
+import Category from '../src/server/db/models/categories';
+import Venue from '../src/server/db/models/venues';
+import Event_Interest from '../src/server/db/models/events_interests';
+
+const PORT = 8000;
+
+const testUser = {
+  username: 'test123',
+  google_id: '1234',
+  email: 'test@test.com',
+  full_name: 'Test User',
+  phone_number: '5554443333',
+};
+
+const now = Date.now();
+
+const testVenue = {
+  city_name: 'New Orleans',
+  state_name: 'LA',
+};
+
+const testEvent = {
+  title: 'Test Event',
+  start_time: new Date(now + 1000 * 60 * 60 * 1),
+  end_time: new Date(now + 1000 * 60 * 60 * 4),
+  address: '123 Fun Blvd',
+  description: 'Testing events with this.',
+  venue_id: 0,
+  category_id: 0,
+  created_by: 0,
+};
+
+function promiseListen(exApp: Application): Promise<http.Server> {
+  return new Promise<http.Server>((resolve, reject) => {
+    const server = exApp.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}.`)
+      resolve(server);
+    });
+
+    server.on('error', (error: Error) => {
+      reject(error);
+    });
+  });
+}
+
+function promiseServerClose(server: http.Server): Promise<void> {
+  return new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    })
+  });
+}
+
+describe('Flare Test Suite', () => {
+
+  let server: http.Server;
+  let user: any;
+  let event: any;
+  let venue: any;
+
+  beforeAll(async () => {
+    try {
+      // Sync database and add test user and test event
+      await database.sync();
+      user = await User.create(testUser);
+      const interests: any[] = await Interest.findAll();
+      const categories: any[] = await Category.findAll();
+      venue = await Venue.create(testVenue);
+
+      testEvent.venue_id = venue.id;
+      testEvent.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+      testEvent.created_by = user.id;
+
+      event = await Event.create(testEvent);
+
+      await Event_Interest.create({
+          EventId: event.id,
+          InterestId: interests[Math.floor(Math.random() * interests.length)].id,
+      });
+      // Build test app with the same routes
+      const app = express();
+      app.use(express.json());
+      app.use((req, res, next) => {
+        req.user = user;
+        next();
+      });
+      app.use('/api', apiRouter);
+      // Then listen
+      server = await promiseListen(app);
+    } catch (error: unknown) {
+      console.error('Failed to start server for testing:', error);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      // Destroy the test user and test event and test venue
+      await user.destroy();
+      await event.destroy();
+      await venue.destroy();
+      // Close the server
+      await promiseServerClose(server);
+    } catch (error: unknown) {
+      console.error('Failed to delete test data from DB and close server:', error);
+    }
+  })
+
+  describe('Event Server Handlers:', () => {
+    test('GET /api/events responds with an array of events', async () => {
+      try {
+        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+          params: {
+            locationFilter: {
+              city: '',
+              state: '',
+            }
+          }
+        });
+        expect(fetchedEvents).toBeDefined();
+        expect(Array.isArray(fetchedEvents)).toBe(true);
+        expect(fetchedEvents.length).toBeGreaterThan(0);
+      } catch (error: unknown) {
+        console.error('Failed to get events for test:', error);
+      }
+    });
+  })
+
+});

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,218 +1,63 @@
-import database from '../src/server/db';
-import http, { Server } from 'http';
 import axios from 'axios';
-import express, { Application } from 'express';
-
-import apiRouter from '../src/server/api';
-import User from '../src/server/db/models/users';
-import Event from '../src/server/db/models/events';
-import Interest from '../src/server/db/models/interests';
-import Category from '../src/server/db/models/categories';
-import Venue from '../src/server/db/models/venues';
-import Event_Interest from '../src/server/db/models/events_interests';
 
 const PORT = 8000;
 
-const testUser1 = {
-  username: 'test123',
-  google_id: '1234',
-  email: 'test@test.com',
-  full_name: 'Test User 1',
-  phone_number: '5554443333',
-};
-
-const testUser2 = {
-  username: 'test456',
-  google_id: '5678',
-  email: 'test2@test.com',
-  full_name: 'Test User 2',
-  phone_number: '9998887777',
-};
-
-const now = Date.now();
-
-const testVenue1 = {
-  city_name: 'New Orleans',
-  state_name: 'LA',
-};
-
-const testVenue2 = {
-  city_name: 'Mandeville',
-  state_name: 'LA',
-};
-
-const testEvent1 = {
-  title: 'Test Event 1',
-  start_time: new Date(now + 1000 * 60 * 60 * 1),
-  end_time: new Date(now + 1000 * 60 * 60 * 4),
-  address: '123 Fun Blvd',
-  description: 'Testing events with this.',
-  venue_id: 0,
-  category_id: 0,
-  created_by: 0,
-};
-
-const testEvent2 = {
-  title: 'Test Event 2',
-  start_time: new Date(now + 1000 * 60 * 60 * 2),
-  end_time: new Date(now + 1000 * 60 * 60 * 5),
-  address: '123 Fun Blvd',
-  description: 'Testing events with this.',
-  venue_id: 0,
-  category_id: 0,
-  created_by: 0,
-};
-
-function promiseListen(exApp: Application): Promise<http.Server> {
-  return new Promise<http.Server>((resolve, reject) => {
-    const server = exApp.listen(PORT, () => {
-      console.log(`Server listening on port ${PORT}.`)
-      resolve(server);
-    });
-
-    server.on('error', (error: Error) => {
-      reject(error);
-    });
-  });
-}
-
-function promiseServerClose(server: http.Server): Promise<void> {
-  return new Promise<void>((resolve) => {
-    server.close(() => {
-      resolve();
-    })
-  });
-}
-
-describe('Flare Test Suite', () => {
-
-  let server: http.Server;
-  let user1: any;
-  let user2: any;
-  let event1: any;
-  let event2: any;
-  let venue1: any;
-  let venue2: any;
-
-  beforeAll(async () => {
+describe('Event Server Handlers:', () => {
+  test('GET /api/events responds with an array of events', async () => {
     try {
-      // Sync database and add test user and test event
-      await database.sync();
-      user1 = await User.create(testUser1);
-      user2 = await User.create(testUser2);
-      const interests: any[] = await Interest.findAll();
-      const categories: any[] = await Category.findAll();
-      venue1 = await Venue.create(testVenue1);
-      venue2 = await Venue.create(testVenue2);
-
-      testEvent1.venue_id = venue1.id;
-      testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
-      testEvent1.created_by = user1.id;
-
-      testEvent2.venue_id = venue2.id;
-      testEvent2.category_id = categories[Math.floor(Math.random() * categories.length)].id;
-      testEvent2.created_by = user2.id;
-
-      event1 = await Event.create(testEvent1);
-      event2 = await Event.create(testEvent2);
-
-      await Event_Interest.create({
-          EventId: event1.id,
-          InterestId: interests[Math.floor(Math.random() * interests.length)].id,
+      const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+        params: {
+          locationFilter: {
+            city: '',
+            state: '',
+          }
+        }
       });
-      await Event_Interest.create({
-          EventId: event2.id,
-          InterestId: interests[Math.floor(Math.random() * interests.length)].id,
-      });
-      // Build test app with the same routes
-      const app = express();
-      app.use(express.json());
-      app.use((req, res, next) => {
-        req.user = user1;
-        next();
-      });
-      app.use('/api', apiRouter);
-      // Then listen
-      server = await promiseListen(app);
+      expect(fetchedEvents).toBeDefined();
+      expect(Array.isArray(fetchedEvents)).toBe(true);
+      expect(fetchedEvents.length).toBeGreaterThanOrEqual(2);
     } catch (error: unknown) {
-      console.error('Failed to start server for testing:', error);
+      console.error('Failed to get events for test:', error);
     }
   });
 
-  describe('Event Server Handlers:', () => {
-    test('GET /api/events responds with an array of events', async () => {
-      try {
-        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
-          params: {
-            locationFilter: {
-              city: '',
-              state: '',
-            }
-          }
-        });
-        expect(fetchedEvents).toBeDefined();
-        expect(Array.isArray(fetchedEvents)).toBe(true);
-        expect(fetchedEvents.length).toBeGreaterThanOrEqual(2);
-      } catch (error: unknown) {
-        console.error('Failed to get events for test:', error);
-      }
-    });
-
-    test('GET /api/events responds with events from a specified location', async () => {
-      try {
-        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
-          params: {
-            locationFilter: {
-              city: 'New Orleans',
-              state: 'LA',
-            }
-          }
-        });
-
-        expect(fetchedEvents).toBeDefined();
-        expect(Array.isArray(fetchedEvents)).toBe(true);
-        expect(fetchedEvents.length).toBeGreaterThanOrEqual(1);
-        expect(fetchedEvents[0].Venue.city_name).toBe('New Orleans');
-        expect(fetchedEvents[0].Venue.state_name).toBe('LA');
-      } catch (error: unknown) {
-        console.error('Failed to get events for test:', error);
-      }
-    });
-
-    test('GET /api/events responds with no events from a location with no events', async () => {
-      try {
-        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
-          params: {
-            locationFilter: {
-              city: 'Nowhere',
-              state: 'XX',
-            }
-          }
-        });
-
-        expect(fetchedEvents).toBeDefined();
-        expect(Array.isArray(fetchedEvents)).toBe(true);
-        expect(fetchedEvents.length).toBe(0);
-      } catch (error: unknown) {
-        console.error('Failed to get events for test:', error);
-      }
-    });
-  })
-
-  afterAll(async () => {
+  test('GET /api/events responds with events from a specified location', async () => {
     try {
-      // Destroy the test user and test event and test venue
-      await user1.destroy();
-      await event1.destroy();
-      await venue1.destroy();
-      await user2.destroy();
-      await event2.destroy();
-      await venue2.destroy();
-      // Close the server
-      await promiseServerClose(server);
+      const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+        params: {
+          locationFilter: {
+            city: 'New Orleans',
+            state: 'LA',
+          }
+        }
+      });
+
+      expect(fetchedEvents).toBeDefined();
+      expect(Array.isArray(fetchedEvents)).toBe(true);
+      expect(fetchedEvents.length).toBeGreaterThanOrEqual(1);
+      expect(fetchedEvents[0].Venue.city_name).toBe('New Orleans');
+      expect(fetchedEvents[0].Venue.state_name).toBe('LA');
     } catch (error: unknown) {
-      console.error('Failed to delete test data from DB and close server:', error);
+      console.error('Failed to get events for test:', error);
     }
   });
 
+  test('GET /api/events responds with no events from a location with no events', async () => {
+    try {
+      const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+        params: {
+          locationFilter: {
+            city: 'Nowhere',
+            state: 'XX',
+          }
+        }
+      });
+
+      expect(fetchedEvents).toBeDefined();
+      expect(Array.isArray(fetchedEvents)).toBe(true);
+      expect(fetchedEvents.length).toBe(0);
+    } catch (error: unknown) {
+      console.error('Failed to get events for test:', error);
+    }
+  });
 });

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -13,25 +13,49 @@ import Event_Interest from '../src/server/db/models/events_interests';
 
 const PORT = 8000;
 
-const testUser = {
+const testUser1 = {
   username: 'test123',
   google_id: '1234',
   email: 'test@test.com',
-  full_name: 'Test User',
+  full_name: 'Test User 1',
   phone_number: '5554443333',
+};
+
+const testUser2 = {
+  username: 'test456',
+  google_id: '5678',
+  email: 'test2@test.com',
+  full_name: 'Test User 2',
+  phone_number: '9998887777',
 };
 
 const now = Date.now();
 
-const testVenue = {
+const testVenue1 = {
   city_name: 'New Orleans',
   state_name: 'LA',
 };
 
-const testEvent = {
-  title: 'Test Event',
+const testVenue2 = {
+  city_name: 'Mandeville',
+  state_name: 'LA',
+};
+
+const testEvent1 = {
+  title: 'Test Event 1',
   start_time: new Date(now + 1000 * 60 * 60 * 1),
   end_time: new Date(now + 1000 * 60 * 60 * 4),
+  address: '123 Fun Blvd',
+  description: 'Testing events with this.',
+  venue_id: 0,
+  category_id: 0,
+  created_by: 0,
+};
+
+const testEvent2 = {
+  title: 'Test Event 2',
+  start_time: new Date(now + 1000 * 60 * 60 * 2),
+  end_time: new Date(now + 1000 * 60 * 60 * 5),
   address: '123 Fun Blvd',
   description: 'Testing events with this.',
   venue_id: 0,
@@ -63,34 +87,47 @@ function promiseServerClose(server: http.Server): Promise<void> {
 describe('Flare Test Suite', () => {
 
   let server: http.Server;
-  let user: any;
-  let event: any;
-  let venue: any;
+  let user1: any;
+  let user2: any;
+  let event1: any;
+  let event2: any;
+  let venue1: any;
+  let venue2: any;
 
   beforeAll(async () => {
     try {
       // Sync database and add test user and test event
       await database.sync();
-      user = await User.create(testUser);
+      user1 = await User.create(testUser1);
+      user2 = await User.create(testUser2);
       const interests: any[] = await Interest.findAll();
       const categories: any[] = await Category.findAll();
-      venue = await Venue.create(testVenue);
+      venue1 = await Venue.create(testVenue1);
+      venue2 = await Venue.create(testVenue2);
 
-      testEvent.venue_id = venue.id;
-      testEvent.category_id = categories[Math.floor(Math.random() * categories.length)].id;
-      testEvent.created_by = user.id;
+      testEvent1.venue_id = venue1.id;
+      testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+      testEvent1.created_by = user1.id;
 
-      event = await Event.create(testEvent);
+      testEvent1.venue_id = venue2.id;
+      testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+      testEvent1.created_by = user2.id;
+
+      event1 = await Event.create(testEvent1);
 
       await Event_Interest.create({
-          EventId: event.id,
+          EventId: event1.id,
+          InterestId: interests[Math.floor(Math.random() * interests.length)].id,
+      });
+      await Event_Interest.create({
+          EventId: event2.id,
           InterestId: interests[Math.floor(Math.random() * interests.length)].id,
       });
       // Build test app with the same routes
       const app = express();
       app.use(express.json());
       app.use((req, res, next) => {
-        req.user = user;
+        req.user = user1;
         next();
       });
       app.use('/api', apiRouter);
@@ -104,9 +141,12 @@ describe('Flare Test Suite', () => {
   afterAll(async () => {
     try {
       // Destroy the test user and test event and test venue
-      await user.destroy();
-      await event.destroy();
-      await venue.destroy();
+      await user1.destroy();
+      await event1.destroy();
+      await venue1.destroy();
+      await user2.destroy();
+      await event2.destroy();
+      await venue2.destroy();
       // Close the server
       await promiseServerClose(server);
     } catch (error: unknown) {
@@ -115,7 +155,7 @@ describe('Flare Test Suite', () => {
   })
 
   describe('Event Server Handlers:', () => {
-    test('GET /api/events responds with an array of events', async () => {
+    test('GET /api/events responds with an array of events ', async () => {
       try {
         const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
           params: {
@@ -125,7 +165,7 @@ describe('Flare Test Suite', () => {
             }
           }
         });
-        expect(fetchedEvents).toBeDefined();
+        expect(fetchedEvents).toBeDefined();+
         expect(Array.isArray(fetchedEvents)).toBe(true);
         expect(fetchedEvents.length).toBeGreaterThan(0);
       } catch (error: unknown) {

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -109,11 +109,12 @@ describe('Flare Test Suite', () => {
       testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
       testEvent1.created_by = user1.id;
 
-      testEvent1.venue_id = venue2.id;
-      testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
-      testEvent1.created_by = user2.id;
+      testEvent2.venue_id = venue2.id;
+      testEvent2.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+      testEvent2.created_by = user2.id;
 
       event1 = await Event.create(testEvent1);
+      event2 = await Event.create(testEvent2);
 
       await Event_Interest.create({
           EventId: event1.id,
@@ -138,6 +139,66 @@ describe('Flare Test Suite', () => {
     }
   });
 
+  describe('Event Server Handlers:', () => {
+    test('GET /api/events responds with an array of events', async () => {
+      try {
+        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+          params: {
+            locationFilter: {
+              city: '',
+              state: '',
+            }
+          }
+        });
+        expect(fetchedEvents).toBeDefined();
+        expect(Array.isArray(fetchedEvents)).toBe(true);
+        expect(fetchedEvents.length).toBeGreaterThanOrEqual(2);
+      } catch (error: unknown) {
+        console.error('Failed to get events for test:', error);
+      }
+    });
+
+    test('GET /api/events responds with events from a specified location', async () => {
+      try {
+        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+          params: {
+            locationFilter: {
+              city: 'New Orleans',
+              state: 'LA',
+            }
+          }
+        });
+
+        expect(fetchedEvents).toBeDefined();
+        expect(Array.isArray(fetchedEvents)).toBe(true);
+        expect(fetchedEvents.length).toBeGreaterThanOrEqual(1);
+        expect(fetchedEvents[0].Venue.city_name).toBe('New Orleans');
+        expect(fetchedEvents[0].Venue.state_name).toBe('LA');
+      } catch (error: unknown) {
+        console.error('Failed to get events for test:', error);
+      }
+    });
+
+    test('GET /api/events responds with no events from a location with no events', async () => {
+      try {
+        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
+          params: {
+            locationFilter: {
+              city: 'Nowhere',
+              state: 'XX',
+            }
+          }
+        });
+
+        expect(fetchedEvents).toBeDefined();
+        expect(Array.isArray(fetchedEvents)).toBe(true);
+        expect(fetchedEvents.length).toBe(0);
+      } catch (error: unknown) {
+        console.error('Failed to get events for test:', error);
+      }
+    });
+  })
+
   afterAll(async () => {
     try {
       // Destroy the test user and test event and test venue
@@ -152,26 +213,6 @@ describe('Flare Test Suite', () => {
     } catch (error: unknown) {
       console.error('Failed to delete test data from DB and close server:', error);
     }
-  })
-
-  describe('Event Server Handlers:', () => {
-    test('GET /api/events responds with an array of events ', async () => {
-      try {
-        const { data: fetchedEvents } = await axios.get(`http://localhost:${PORT}/api/event`, {
-          params: {
-            locationFilter: {
-              city: '',
-              state: '',
-            }
-          }
-        });
-        expect(fetchedEvents).toBeDefined();+
-        expect(Array.isArray(fetchedEvents)).toBe(true);
-        expect(fetchedEvents.length).toBeGreaterThan(0);
-      } catch (error: unknown) {
-        console.error('Failed to get events for test:', error);
-      }
-    });
-  })
+  });
 
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,138 @@
+import database from '../src/server/db';
+import http from 'http';
+import express, { Application } from 'express';
+
+import apiRouter from '../src/server/api';
+import User from '../src/server/db/models/users';
+import Event from '../src/server/db/models/events';
+import Interest from '../src/server/db/models/interests';
+import Category from '../src/server/db/models/categories';
+import Venue from '../src/server/db/models/venues';
+import Event_Interest from '../src/server/db/models/events_interests';
+
+export default async function () {
+  const PORT = 8000;
+
+  const testUser1 = {
+    username: 'test123',
+    google_id: '1234',
+    email: 'test@test.com',
+    full_name: 'Test User 1',
+    phone_number: '5554443333',
+  };
+
+  const testUser2 = {
+    username: 'test456',
+    google_id: '5678',
+    email: 'test2@test.com',
+    full_name: 'Test User 2',
+    phone_number: '9998887777',
+  };
+
+  const now = Date.now();
+
+  const testVenue1 = {
+    city_name: 'New Orleans',
+    state_name: 'LA',
+  };
+
+  const testVenue2 = {
+    city_name: 'Mandeville',
+    state_name: 'LA',
+  };
+
+  const testEvent1 = {
+    title: 'Test Event 1',
+    start_time: new Date(now + 1000 * 60 * 60 * 1),
+    end_time: new Date(now + 1000 * 60 * 60 * 4),
+    address: '123 Fun Blvd',
+    description: 'Testing events with this.',
+    venue_id: 0,
+    category_id: 0,
+    created_by: 0,
+  };
+
+  const testEvent2 = {
+    title: 'Test Event 2',
+    start_time: new Date(now + 1000 * 60 * 60 * 2),
+    end_time: new Date(now + 1000 * 60 * 60 * 5),
+    address: '123 Fun Blvd',
+    description: 'Testing events with this.',
+    venue_id: 0,
+    category_id: 0,
+    created_by: 0,
+  };
+
+  function promiseListen(exApp: Application): Promise<http.Server> {
+    return new Promise<http.Server>((resolve, reject) => {
+      const server = exApp.listen(PORT, () => {
+        console.log(`Server listening on port ${PORT}.`)
+        resolve(server);
+      });
+
+      server.on('error', (error: Error) => {
+        reject(error);
+      });
+    });
+  }
+
+  let testServer: http.Server;
+  let user1: any;
+  let user2: any;
+  let event1: any;
+  let event2: any;
+  let venue1: any;
+  let venue2: any;
+
+  try {
+    // Sync database and add test user and test event
+    await database.sync();
+    user1 = await User.create(testUser1);
+    user2 = await User.create(testUser2);
+    const interests: any[] = await Interest.findAll();
+    const categories: any[] = await Category.findAll();
+    venue1 = await Venue.create(testVenue1);
+    venue2 = await Venue.create(testVenue2);
+
+    testEvent1.venue_id = venue1.id;
+    testEvent1.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+    testEvent1.created_by = user1.id;
+
+    testEvent2.venue_id = venue2.id;
+    testEvent2.category_id = categories[Math.floor(Math.random() * categories.length)].id;
+    testEvent2.created_by = user2.id;
+
+    event1 = await Event.create(testEvent1);
+    event2 = await Event.create(testEvent2);
+
+    await Event_Interest.create({
+        EventId: event1.id,
+        InterestId: interests[Math.floor(Math.random() * interests.length)].id,
+    });
+    await Event_Interest.create({
+        EventId: event2.id,
+        InterestId: interests[Math.floor(Math.random() * interests.length)].id,
+    });
+    // Build test app with the same routes
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      req.user = user1;
+      next();
+    });
+    app.use('/api', apiRouter);
+    // Then listen
+    testServer = await promiseListen(app);
+
+    globalThis.testServer = testServer;
+    globalThis.user1 = user1;
+    globalThis.user2 = user2;
+    globalThis.event1 = event1;
+    globalThis.event2 = event2;
+    globalThis.venue1 = venue1;
+    globalThis.venue2 = venue2;
+    globalThis.PORT = PORT;
+  } catch (error: unknown) {
+    console.error('Failed to start server for testing:', error);
+  }
+}

--- a/tests/teardown.ts
+++ b/tests/teardown.ts
@@ -1,0 +1,25 @@
+import http from 'http';
+
+export default async function () {
+  function promiseServerClose(server: http.Server): Promise<void> {
+    return new Promise<void>((resolve) => {
+      server.close(() => {
+        resolve();
+      })
+    });
+  }
+
+  try {
+    // Destroy the test user and test event and test venue
+    globalThis.user1.destroy();
+    globalThis.event1.destroy();
+    globalThis.venue1.destroy();
+    globalThis.user2.destroy();
+    globalThis.event2.destroy();
+    globalThis.venue2.destroy();
+    // Close the server
+    await promiseServerClose(globalThis.testServer);
+  } catch (error: unknown) {
+    console.error('Failed to delete test data from DB and close server:', error);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "noEmit": true,
     "noImplicitReturns": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "module": "commonjs",
     "moduleDetection": "force",
     "moduleResolution": "node",


### PR DESCRIPTION
- Jest Setup:
  - Seed DB for two users, two events, and two venues
  - Start a server on PORT 8000 with a req.user and all /api routers.
- Jest Teardown:
  - Destroy the users, events, and venues created
  - Stop listening to the server
- Added tests for GET /api/events:
  - Fetch all events without a LocFilter
  - Fetch events with a LocFilter for events in location
  - Fetch events with a LocFilter for no events in location