### PR TITLE
feat / Events User Picks For Images and Tags

### DIFF
--- a/src/client/components/events-view/Event.tsx
+++ b/src/client/components/events-view/Event.tsx
@@ -27,63 +27,10 @@ import { UserContext } from '../../contexts/UserContext';
 
 import EventDrawerContent from './EventDrawerContent';
 
+import { EventData } from '@/types/Events';
+
 type EventProps = {
-  event: {
-    id: number;
-    title: string;
-    start_time: Date;
-    end_time: Date;
-    address: string;
-    description: string;
-    venue_id: number;
-    created_by: number;
-    chatroom_id: number;
-    createdAt: Date;
-    updatedAt: Date;
-    hour_before_notif: number;
-    User_Event?: {
-      user_attending: boolean;
-    };
-    Users?: {
-      id: number;
-      username: string;
-      full_name: string;
-      User_Event: {
-        user_attending: boolean;
-      };
-    }[];
-    Category?: {
-      id: number;
-      name: string;
-    };
-    Interests: {
-      id: number;
-      name: string;
-    }[];
-    Venue: {
-      id: number;
-      name: string;
-      description: string | null;
-      street_address: string | null;
-      city_name: string | null;
-      state_name: string | null;
-      zip_code: number | null;
-      category: string | null;
-      phone: string | null;
-      popularTime: Date | null;
-      pricing: string | null;
-      serves_alcohol: boolean | null;
-      website: string | null;
-      wheelchair_accessible: boolean | null;
-      Venue_Tags: {
-        count: number;
-        tag: string;
-      }[];
-      Venue_Images: {
-        path: string;
-      }[];
-    };
-  };
+  event: EventData;
   getEvents: () => void;
 };
 

--- a/src/client/components/events-view/Event.tsx
+++ b/src/client/components/events-view/Event.tsx
@@ -39,7 +39,7 @@ function Event({ event, getEvents }: EventProps) {
 
   const [venuePicIndex, setVenuePicIndex] = useState<number>(0);
 
-  const { title, start_time, end_time, Users, Venue } = event;
+  const { title, start_time, end_time, Users, Venue, Venue_Images } = event;
 
   const buttonColor = 'bg-gradient-to-r from-yellow-500 via-orange-500 to-pink-500 hover:from-yellow-600 hover:via-orange-600 hover:to-pink-600 text-white px-2 py-2 rounded-xl text-sm';
 
@@ -70,7 +70,9 @@ function Event({ event, getEvents }: EventProps) {
   }, [Users, user.id]);
 
   const venuePics: string[] = useMemo(() => (
-    Venue?.Venue_Images.map((image) => image.path)
+    Venue_Images
+      .sort((a, b) => a.Event_Venue_Image.display_order - b.Event_Venue_Image.display_order)
+      .map((image) => image.path)
   ), [Venue]);
 
   const postAttendEvent = () => {

--- a/src/client/components/events-view/EventDetails.tsx
+++ b/src/client/components/events-view/EventDetails.tsx
@@ -11,63 +11,10 @@ import { Button } from '@/components/ui/button';
 
 import TTSButton from '../a11y/TTSButton';
 
+import { EventData } from '@/types/Events';
+
 type EventDetailsProps = {
-  event: {
-    id: number;
-    title: string;
-    start_time: Date;
-    end_time: Date;
-    address: string;
-    description: string;
-    venue_id: number;
-    created_by: number;
-    chatroom_id: number;
-    createdAt: Date;
-    updatedAt: Date;
-    User_Event?: {
-      user_attending: boolean;
-    };
-    Users?: {
-      id: number;
-      username: string;
-      full_name: string;
-      avatar_uri: string;
-      User_Event: {
-        user_attending: boolean;
-      };
-    }[];
-    Category?: {
-      id: number;
-      name: string;
-    };
-    Interests: {
-      id: number;
-      name: string;
-    }[];
-    Venue: {
-      id: number;
-      name: string;
-      description: string | null;
-      street_address: string | null;
-      city_name: string | null;
-      state_name: string | null;
-      zip_code: number | null;
-      category: string | null;
-      phone: string | null;
-      popularTime: Date | null;
-      pricing: string | null;
-      serves_alcohol: boolean | null;
-      website: string | null;
-      wheelchair_accessible: boolean | null;
-      Venue_Tags: {
-        count: number;
-        tag: string;
-      }[];
-      Venue_Images: {
-        path: string;
-      }[];
-    };
-  };
+  event: EventData;
   openVenueDetails: () => void;
 };
 
@@ -188,7 +135,7 @@ function EventDetails({ event, openVenueDetails }: EventDetailsProps) {
             <b>Who is attending?</b>
             <div className="grid grid-cols-2 gap-4">
               {Users?.map((user) => {
-                const { username, full_name, User_Event, avatar_uri } = user;
+                const { username, full_name, User_Event } = user;
                 return User_Event.user_attending ? (
                   <div
                     key={Math.random().toString(36).slice(0, 7)}

--- a/src/client/components/events-view/EventDrawerContent.tsx
+++ b/src/client/components/events-view/EventDrawerContent.tsx
@@ -17,62 +17,10 @@ import VenueDetails from './VenueDetails';
 
 import ScheduleTextDialog from './ScheduleTextDialog';
 
+import { EventData } from '@/types/Events';
+
 type EventDrawerContentProps = {
-  event: {
-    id: number;
-    title: string;
-    start_time: Date;
-    end_time: Date;
-    address: string;
-    description: string;
-    venue_id: number;
-    created_by: number;
-    chatroom_id: number;
-    createdAt: Date;
-    updatedAt: Date;
-    User_Event?: {
-      user_attending: boolean;
-    };
-    Users?: {
-      id: number;
-      username: string;
-      full_name: string;
-      User_Event: {
-        user_attending: boolean;
-      };
-    }[];
-    Category?: {
-      id: number;
-      name: string;
-    };
-    Interests: {
-      id: number;
-      name: string;
-    }[];
-    Venue: {
-      id: number;
-      name: string;
-      description: string | null;
-      street_address: string | null;
-      city_name: string | null;
-      state_name: string | null;
-      zip_code: number | null;
-      category: string | null;
-      phone: string | null;
-      popularTime: Date | null;
-      pricing: string | null;
-      serves_alcohol: boolean | null;
-      website: string | null;
-      wheelchair_accessible: boolean | null;
-      Venue_Tags: {
-        count: number;
-        tag: string;
-      }[];
-      Venue_Images: {
-        path: string;
-      }[];
-    };
-  };
+  event: EventData;
   postAttendEvent: () => void;
   patchAttendingEvent: (isAttending: boolean) => void;
   category: string;

--- a/src/client/components/events-view/EventDrawerContent.tsx
+++ b/src/client/components/events-view/EventDrawerContent.tsx
@@ -34,7 +34,7 @@ function EventDrawerContent({
 }: EventDrawerContentProps) {
   const [showVenueDetails, setShowVenueDetails] = useState<boolean>(false);
 
-  const { start_time, end_time, Venue, Category, id } = event;
+  const { start_time, end_time, Venue, Category, id, Venue_Tags } = event;
 
   const normalDrawerButton = 'bg-gradient-to-r from-black via-gray-900 to-pink-900 hover:from-black hover:via-gray-700 hover:to-pink-700 text-white flex items-center';
   
@@ -58,7 +58,7 @@ function EventDrawerContent({
     <div className="mx-auto w-full max-w-sm">
       {
         showVenueDetails
-          ? <VenueDetails venue={Venue} closeVenueDetails={closeVenueDetails} />
+          ? <VenueDetails venue={Venue} eventVenueTags={Venue_Tags} closeVenueDetails={closeVenueDetails} />
           : <EventDetails event={event} openVenueDetails={openVenueDetails} />
       }
       <DrawerFooter>

--- a/src/client/components/events-view/EventsList.tsx
+++ b/src/client/components/events-view/EventsList.tsx
@@ -2,47 +2,10 @@ import React from 'react';
 
 import Event from './Event';
 
+import { EventData } from '@/types/Events';
+
 type EventsListProps = {
-  events: {
-    id: number;
-    title: string;
-    start_time: Date;
-    end_time: Date;
-    address: string;
-    description: string;
-    venue_id: number;
-    created_by: number;
-    chatroom_id: number;
-    createdAt: Date;
-    updatedAt: Date;
-    hour_before_notif: number;
-    User_Event?: {
-      user_attending: boolean;
-    };
-    Venue: {
-      id: number;
-      name: string;
-      description: string | null;
-      street_address: string | null;
-      city_name: string | null;
-      state_name: string | null;
-      zip_code: number | null;
-      category: string | null;
-      phone: string | null;
-      popularTime: Date | null;
-      pricing: string | null;
-      serves_alcohol: boolean | null;
-      website: string | null;
-      wheelchair_accessible: boolean | null;
-      Venue_Tags: {
-        count: number;
-        tag: string;
-      }[];
-      Venue_Images: {
-        path: string;
-      }[];
-    };
-  }[];
+  events: EventData[];
   getEvents: () => void;
 };
 

--- a/src/client/components/events-view/VenueDetails.tsx
+++ b/src/client/components/events-view/VenueDetails.tsx
@@ -39,10 +39,17 @@ type VenueDetailsProps = {
       path: string;
     }[];
   };
+  eventVenueTags: {
+    count: number;
+    tag: string;
+    Event_Venue_Tag: {
+      display_order: number;
+    };
+  }[];
   closeVenueDetails: () => void;
 }
 
-function VenueDetails({ venue, closeVenueDetails }: VenueDetailsProps) {
+function VenueDetails({ venue, eventVenueTags, closeVenueDetails }: VenueDetailsProps) {
   const {
     name,
     description,
@@ -71,8 +78,8 @@ function VenueDetails({ venue, closeVenueDetails }: VenueDetailsProps) {
   `;
 
   const tags: string = useMemo(() => (
-    Venue_Tags
-      .sort((a, b) => b.count - a.count)
+    eventVenueTags
+      .sort((a, b) => a.Event_Venue_Tag.display_order - b.Event_Venue_Tag.display_order)
       .map(({ tag }) => tag)
       .join(', ')
   ), [Venue_Tags]);

--- a/src/client/components/events-view/VenueDetails.tsx
+++ b/src/client/components/events-view/VenueDetails.tsx
@@ -31,13 +31,6 @@ type VenueDetailsProps = {
     wheelchair_accessible: boolean | null;
     is_dog_friendly: boolean | null;
     is_vegan_friendly: boolean | null;
-    Venue_Tags: {
-      count: number;
-      tag: string;
-    }[];
-    Venue_Images: {
-      path: string;
-    }[];
   };
   eventVenueTags: {
     count: number;

--- a/src/client/components/events-view/VenueDetails.tsx
+++ b/src/client/components/events-view/VenueDetails.tsx
@@ -29,6 +29,8 @@ type VenueDetailsProps = {
     serves_alcohol: boolean | null;
     website: string | null;
     wheelchair_accessible: boolean | null;
+    is_dog_friendly: boolean | null;
+    is_vegan_friendly: boolean | null;
     Venue_Tags: {
       count: number;
       tag: string;

--- a/src/client/components/events-view/VenueDetails.tsx
+++ b/src/client/components/events-view/VenueDetails.tsx
@@ -64,7 +64,8 @@ function VenueDetails({ venue, eventVenueTags, closeVenueDetails }: VenueDetails
     serves_alcohol,
     website,
     wheelchair_accessible,
-    Venue_Tags,
+    is_dog_friendly,
+    is_vegan_friendly,
   } = venue;
 
   const normalDrawerButton = 'bg-gradient-to-r from-black via-gray-900 to-pink-900 hover:from-black hover:via-gray-700 hover:to-pink-700 text-white';
@@ -82,7 +83,7 @@ function VenueDetails({ venue, eventVenueTags, closeVenueDetails }: VenueDetails
       .sort((a, b) => a.Event_Venue_Tag.display_order - b.Event_Venue_Tag.display_order)
       .map(({ tag }) => tag)
       .join(', ')
-  ), [Venue_Tags]);
+  ), [eventVenueTags]);
 
   const venueDetailsTTS: string = useMemo(() => (
     `
@@ -95,7 +96,7 @@ function VenueDetails({ venue, eventVenueTags, closeVenueDetails }: VenueDetails
       ${pricing ? `Pricing: ${pricing}` : ''}
       ${serves_alcohol !== null ? `Serves Alcohol? ${serves_alcohol ? 'Yes.' : 'No.'}` : ''}
       ${wheelchair_accessible !== null ? `Wheelchair Accessible? ${wheelchair_accessible ? 'Yes.' : 'No.'}` : ''}
-      ${Venue_Tags.length > 0 ? `Tags: ${tags}` : ''}
+      ${eventVenueTags.length > 0 ? `Tags: ${tags}` : ''}
     `
   ), [venue, tags]);
 
@@ -209,7 +210,23 @@ function VenueDetails({ venue, eventVenueTags, closeVenueDetails }: VenueDetails
             ) : null
           }
           {
-            Venue_Tags.length > 0 ? (
+            is_dog_friendly !== null ? (
+              <div>
+                <b>Dog Friendly:</b>
+                <p>{is_dog_friendly ? 'Yes' : 'No'}</p>
+              </div>
+            ) : null
+          }
+          {
+            is_vegan_friendly !== null ? (
+              <div>
+                <b>Vegan Friendly:</b>
+                <p>{is_vegan_friendly ? 'Yes' : 'No'}</p>
+              </div>
+            ) : null
+          }
+          {
+            eventVenueTags.length > 0 ? (
               <div className="col-span-2">
                 <b>Tags:</b>
                 <p>{tags}</p>

--- a/src/client/views/Events.tsx
+++ b/src/client/views/Events.tsx
@@ -26,50 +26,11 @@ import InterestsFilter from '../components/events-view/InterestsFilter';
 
 import EventsList from '../components/events-view/EventsList';
 
+import { EventData } from '@/types/Events';
+
 type Location = {
   city: string;
   state: string;
-};
-
-type EventData = {
-  id: number;
-  title: string;
-  start_time: Date;
-  end_time: Date;
-  address: string;
-  description: string;
-  venue_id: number;
-  created_by: number;
-  chatroom_id: number;
-  createdAt: Date;
-  updatedAt: Date;
-  hour_before_notif: number;
-  User_Event?: {
-    user_attending: boolean;
-  };
-  Venue: {
-    id: number;
-    name: string;
-    description: string | null;
-    street_address: string | null;
-    city_name: string | null;
-    state_name: string | null;
-    zip_code: number | null;
-    category: string | null;
-    phone: string | null;
-    popularTime: Date | null;
-    pricing: string | null;
-    serves_alcohol: boolean | null;
-    website: string | null;
-    wheelchair_accessible: boolean | null;
-    Venue_Tags: {
-      count: number;
-      tag: string;
-    }[];
-    Venue_Images: {
-      path: string;
-    }[];
-  };
 };
 
 function Events() {
@@ -174,6 +135,8 @@ function Events() {
   useEffect(() => {
     getEvents();
   }, [locationFilter, catFilter, interestsFilter]);
+
+  console.log(events);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-pink-900 relative overflow-hidden pt-20 pb-12">

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -46,14 +46,6 @@ event2Router.get('/', (req: any, res: Response) => {
       },
       {
         model: Venue,
-        include: [
-          {
-            model: Venue_Tag,
-          },
-          {
-            model: Venue_Image,
-          },
-        ],
       },
       {
         association: 'Category',
@@ -148,14 +140,6 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
         },
         {
           model: Venue,
-          include: [
-            {
-              model: Venue_Tag,
-            },
-            {
-              model: Venue_Image,
-            },
-          ],
         },
         {
           association: 'Category',

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -64,6 +64,12 @@ event2Router.get('/', (req: any, res: Response) => {
       {
         association: 'Users',
       },
+      {
+        association: 'Venue_Images',
+      },
+      {
+        association: 'Venue_Tags',
+      },
     ],
   })
     .then((events: any) => {
@@ -159,6 +165,12 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
         },
         {
           association: 'Users',
+        },
+        {
+          association: 'Venue_Images',
+        },
+        {
+          association: 'Venue_Tags',
         },
       ],
     },

--- a/src/types/Events.ts
+++ b/src/types/Events.ts
@@ -1,0 +1,71 @@
+export type EventData = {
+  id: number;
+  title: string;
+  start_time: Date;
+  end_time: Date;
+  address: string;
+  description: string;
+  venue_id: number;
+  created_by: number;
+  chatroom_id: number;
+  createdAt: Date;
+  updatedAt: Date;
+  hour_before_notif: number;
+  User_Event?: {
+    user_attending: boolean;
+  };
+  Users?: {
+    id: number;
+    username: string;
+    full_name: string;
+    User_Event: {
+      user_attending: boolean;
+    };
+  }[];
+  Category?: {
+    id: number;
+    name: string;
+  };
+  Interests: {
+    id: number;
+    name: string;
+  }[];
+  Venue: {
+    id: number;
+    name: string;
+    description: string | null;
+    street_address: string | null;
+    city_name: string | null;
+    state_name: string | null;
+    zip_code: number | null;
+    category: string | null;
+    phone: string | null;
+    popularTime: Date | null;
+    pricing: string | null;
+    serves_alcohol: boolean | null;
+    website: string | null;
+    wheelchair_accessible: boolean | null;
+    is_dog_friendly: boolean | null;
+    is_vegan_friendly: boolean | null;
+    Venue_Tags: {
+      count: number;
+      tag: string;
+    }[];
+    Venue_Images: {
+      path: string;
+    }[];
+  };
+  Venue_Images: {
+    path: string;
+    Event_Venue_Image: {
+      display_order: number;
+    };
+  }[];
+  Venue_Tags: {
+    count: number;
+    tag: string;
+    Event_Venue_Tag: {
+      display_order: number;
+    };
+  }[];
+};

--- a/src/types/Events.ts
+++ b/src/types/Events.ts
@@ -11,10 +11,10 @@ export type EventData = {
   createdAt: Date;
   updatedAt: Date;
   hour_before_notif: number;
-  User_Event?: {
+  User_Event: {
     user_attending: boolean;
   };
-  Users?: {
+  Users: {
     id: number;
     username: string;
     full_name: string;
@@ -22,7 +22,7 @@ export type EventData = {
       user_attending: boolean;
     };
   }[];
-  Category?: {
+  Category: {
     id: number;
     name: string;
   };
@@ -47,13 +47,6 @@ export type EventData = {
     wheelchair_accessible: boolean | null;
     is_dog_friendly: boolean | null;
     is_vegan_friendly: boolean | null;
-    Venue_Tags: {
-      count: number;
-      tag: string;
-    }[];
-    Venue_Images: {
-      path: string;
-    }[];
   };
   Venue_Images: {
     path: string;


### PR DESCRIPTION
BUG ALERT:
- Venue Id isn't being assigned to Event
  - Colton is aware and looking into it.
  - Work around until fix: Manually assign venue_id in MySQL Shell until Colton's PR with the fix

PR Details:
- Server Request Handlers include Event Venue Pics and Tags for the event itself
- Removed the inclusion of the Venue Pics and Tags on the venue
- TS: Create EventData type for the data retrieved from GET /api/event and similar handlers
- Refactor: All components in Events view uses EventData type now
- User will now see the following:
  - User selected pics in the order they were picked in event creation for Event Card
  - User selected tags in the order they were picked in event creation for Venue Details
  - Dog Friendly info for Venue Details
  - Vegan Friendly info for Venue Details