### PR TITLE
Optimize events

### DIFF
--- a/src/client/components/events-view/Event.tsx
+++ b/src/client/components/events-view/Event.tsx
@@ -32,9 +32,10 @@ import { EventData } from '@/types/Events';
 type EventProps = {
   event: EventData;
   getEvents: () => void;
+  disableBail?: boolean;
 };
 
-function Event({ event, getEvents }: EventProps) {
+function Event({ event, getEvents, disableBail }: EventProps) {
   const { user } = useContext(UserContext);
 
   const [venuePicIndex, setVenuePicIndex] = useState<number>(0);
@@ -144,6 +145,7 @@ function Event({ event, getEvents }: EventProps) {
                     <EventDrawerContent
                       event={event}
                       category={category}
+                      disableBail={disableBail}
                       postAttendEvent={postAttendEvent}
                       patchAttendingEvent={patchAttendingEvent}
                     />

--- a/src/client/components/events-view/EventDrawerContent.tsx
+++ b/src/client/components/events-view/EventDrawerContent.tsx
@@ -24,11 +24,13 @@ type EventDrawerContentProps = {
   postAttendEvent: () => void;
   patchAttendingEvent: (isAttending: boolean) => void;
   category: string;
+  disableBail?: boolean;
 };
 
 function EventDrawerContent({
   event,
   category,
+  disableBail,
   postAttendEvent,
   patchAttendingEvent,
 }: EventDrawerContentProps) {
@@ -85,7 +87,7 @@ function EventDrawerContent({
             </Dialog>
           </div>
         ) : null}
-        {category === 'attending' ? (
+        {category === 'attending' && (!disableBail) ? (
           <Button className={warnDrawerButton} onClick={() => {
             patchAttendingEvent(false);
           }}>Bail {<TbCircleDashedLetterB />}</Button>

--- a/src/client/views/Dashboard.tsx
+++ b/src/client/views/Dashboard.tsx
@@ -280,7 +280,11 @@ function Dashboard() {
                 </div>
                 {
                   closestEvent ? (
-                    <Event event={closestEvent} getEvents={() => {}} />
+                    <Event
+                      event={closestEvent}
+                      getEvents={() => {}}
+                      disableBail={true}
+                    />
                   ) : (
                     <p className="text-gray-200 text-lg">
                       No upcoming events scheduled

--- a/src/client/views/Dashboard.tsx
+++ b/src/client/views/Dashboard.tsx
@@ -163,8 +163,13 @@ function Dashboard() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const response = await axios.get('/api/events/nearest');
-        setClosestEvent(response.data);
+        const response = await axios.get('/api/event/attend/true', {
+          params: {
+            now: new Date().toISOString(),
+            limit: 1,
+          }
+        });
+        setClosestEvent(response.data[0]);
       } catch (error) {
         console.error('Error fetching closest event:', error);
       }
@@ -182,6 +187,7 @@ function Dashboard() {
     setIsOpen(false);
     setCurrFlare(null);
   }
+
   return (
     <ErrorBoundary>
       <div className="min-h-screen bg-gradient-to-br from-black via-gray-900 to-pink-900 relative overflow-hidden pt-20 pb-12">

--- a/src/client/views/Dashboard.tsx
+++ b/src/client/views/Dashboard.tsx
@@ -40,6 +40,8 @@ import cn from '../../../lib/utils';
 import PhoenixLogo from '../assets/logo/phoenix.png';
 import { Weather } from '../components/dashboard/Weather';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
+import Event from '../components/events-view/Event';
+import { EventData } from '@/types/Events';
 
 type Task = {
   id: number;
@@ -73,7 +75,7 @@ function Dashboard() {
   const [completeDisabled, setCompleteDisabled] = useState(false);
   const [userFlares, setUserFlares] = useState<FlareType[]>([]);
   const [unearnedFlares, setUnearnedFlares] = useState<FlareType[]>([]);
-  const [closestEvent, setClosestEvent] = useState<{ title: string } | null>(
+  const [closestEvent, setClosestEvent] = useState<EventData | null>(
     null
   );
   const [latestFlare, setLatestFlare] = useState<{ name: string } | null>(null);
@@ -276,9 +278,15 @@ function Dashboard() {
                     Next Event
                   </h2>
                 </div>
-                <p className="text-gray-200 text-lg">
-                  {closestEvent?.title || 'No upcoming events scheduled'}
-                </p>
+                {
+                  closestEvent ? (
+                    <Event event={closestEvent} getEvents={() => {}} />
+                  ) : (
+                    <p className="text-gray-200 text-lg">
+                      No upcoming events scheduled
+                    </p>
+                  )
+                }
               </motion.div>
 
               {/* Task Display */}

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -130,13 +130,15 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
     isAttending = false;
   }
 
-  User.findOne({
+  User_Event.findAll({
     where: {
-      id: req.user.id,
+      UserId: req.user.id,
+      user_attending: isAttending,
     },
     order: [
       [Event, 'start_time', 'ASC']
     ],
+    attributes: [],
     include: {
       model: Event,
       where: { end_time: { [Op.gt]: now } },
@@ -166,12 +168,9 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
     },
   })
     .then((data) => {
+      const events: any = data.map((userEvent: any) => userEvent.Event);
       res.status(200);
-      res.send(
-        data?.dataValues.Events.filter(
-          (event: any) => event.User_Event.user_attending === isAttending
-        )
-      );
+      res.send(events);
     })
     .catch((err: unknown) => {
       console.error('Failed to GET /api/event/attend', err);

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -37,6 +37,10 @@ event2Router.get('/', (req: any, res: Response) => {
     whereFilter['$Category.name$'] = { [Op.or]: req.query.catFilter };
   }
 
+  if (req.query.interestsFilter) {
+    whereFilter['$Interests.name$'] = req.query.interestsFilter;
+  }
+
   // Query DB for all event objects & send them back to the user
   Event.findAll({
     where: whereFilter,
@@ -68,12 +72,6 @@ event2Router.get('/', (req: any, res: Response) => {
     ],
   })
     .then((events: any) => {
-      // If an interests filter is being used, only grab events that contain an interest from the filter
-      if (req.query.interestsFilter) {
-        const intFilter: string[] = req.query.interestsFilter;
-        // Future Task: Optimize this approach. This will not scale well with a large amounts of events
-        events = events.filter((event: any) => event.Interests.some((interest: any) => intFilter.includes(interest.name)));
-      }
       res.status(200);
       res.send(events);
     })

--- a/src/server/routes/event2.ts
+++ b/src/server/routes/event2.ts
@@ -136,7 +136,6 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
     order: [
       [Event, 'start_time', 'ASC']
     ],
-    attributes: [],
     include: {
       model: Event,
       where: { end_time: { [Op.gt]: now } },
@@ -166,7 +165,11 @@ event2Router.get('/attend/:isAttending', (req: any, res: Response) => {
     },
   })
     .then((data) => {
-      const events: any = data.map((userEvent: any) => userEvent.Event);
+      let events: any = data.map((userEvent: any) => userEvent.Event);
+      // Sequelize is having issues with limit interacting with order and where clauses for associated models
+      if (req.query.limit) {
+        events = events.slice(0, +(req.query.limit));
+      }
       res.status(200);
       res.send(events);
     })


### PR DESCRIPTION
- Optimized the GET requests for events to return faster for user
- Add limit query for GET /api/event/attend/:isAttending
  - Sequelize's Limit option was giving me issues
  - It didn't interact well with where and order clauses using associated models
  - I am using slice before sending data.
- Dashboard uses that route with limit set to 1
- Dashboard shows event card for the next upcoming event the user is attending with Bail button disabled